### PR TITLE
Explicitly specify ActivationType and CostType when instantiating Net…

### DIFF
--- a/include/algebra.hpp
+++ b/include/algebra.hpp
@@ -7,6 +7,18 @@
 using Eigen::MatrixXf;
 using Eigen::VectorXf;
 
+enum class CostType : unsigned char
+{
+    Quadratic,
+    CrossEntropy
+};
+
+enum class ActivationType : unsigned char
+{
+    Sigmoid,
+    Softmax
+};
+
 class Activation
 {
 public:

--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -13,19 +13,13 @@
 
 using Eigen::VectorXf;
 
-enum class NetworkActivationMode : unsigned char
-{
-    Sigmoid=0,
-    Softmax=1
-};
-
 class Network
 {
 public:
-    Network(const int sizes[], const int& N, const NetworkActivationMode& mode);
-    Network(const std::string& fileName);
-    
+    Network(const int sizes[], const int& N, const ActivationType& actiType, const CostType& costType);
     ~Network();
+    
+    static Network* loadFile(const std::string& fileName);
     
     void SGD(Dataset& dataset, const size_t& miniBatchSize, const size_t& epoch, const float& eta, const bool displayProgress = false);
     void feedForward(VectorXf& input) const;
@@ -39,10 +33,14 @@ public:
     void getStats() const;
         
     float evaluateAccuracy(Dataset& dataset) const;
-
+    
+    const ActivationType activationType;
+    const CostType costType;
+    
+    bool operator == (const Network& other) const;
 private:
     // Construction
-    int m_size;
+    const int m_size;
     const int* m_sizes;
     BaseLayer** m_layers;
     

--- a/include/layer.hpp
+++ b/include/layer.hpp
@@ -16,12 +16,10 @@ using Eigen::VectorXf;
 class BaseLayer
 {
 public:
-    BaseLayer(const int& in, const int& out,
-              const unsigned char& activationMode);
+    BaseLayer(const int& in, const int& out, const ActivationType& actiType);
     virtual ~BaseLayer();
     
     // Getters
-    size_t getSize() const;
     MatrixXf* getTempWeight() const;
     
     // Main methods
@@ -45,11 +43,12 @@ public:
     void toBinary(boost::archive::binary_oarchive & ar) const;
     void fromBinary(boost::archive::binary_iarchive & ar);
 
+    bool equals(BaseLayer* other) const;
+    
+    const int inSize;
+    const int outSize;
 protected:
     static std::mt19937 Generator;
-    
-    const int m_inSize;
-    const int m_outSize;
     
     // Current weights and biases
     VectorXf* m_biases;
@@ -75,8 +74,7 @@ private:
 class HiddenLayer : public BaseLayer
 {
 public :
-    HiddenLayer(const int& in, const int& out,
-                unsigned char activationMode=0);
+    HiddenLayer(const int& in, const int& out, const ActivationType& actiType);
     
     void getDelta(VectorXf& a) const override;
 };
@@ -84,9 +82,7 @@ public :
 class OutputLayer : public BaseLayer
 {
 public:
-    OutputLayer(const int& in, const int& out,
-                const unsigned char& activationMode,
-                unsigned char costMode=0);
+    OutputLayer(const int& in, const int& out, const ActivationType& actiType, const CostType& costType);
     ~OutputLayer();
     
     void getDelta(VectorXf& a) const override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ void saveAndLoad()
     // Initialize a network with 3 hidden layers
     const int N(5);
     const int sizes[N] = {100, 30, 25, 20, 10};
-    Network net(sizes, N, NetworkActivationMode::Sigmoid);
+    Network net(sizes, N, ActivationType::Sigmoid, CostType::Quadratic);
     
     // Export to CSV
     std::cout << "Exporting to CSV..." << std::endl;
@@ -22,13 +22,8 @@ void saveAndLoad()
     
     // Load from binary
     std::cout << "Loading from binary..." << std::endl;
-    Network net2("./exports/myNetwork");
-    
-//    const int sizes_different[N-1] = {100, 30, 20, 20};
-    Network net3(sizes, N, NetworkActivationMode::Sigmoid);
-    std::ifstream file("./exports/myNetwork", std::ios::binary);
-    boost::archive::binary_iarchive ar(file);
-    net3.loadBinary(ar);
+    Network* net2 = Network::loadFile("./exports/myNetwork");
+    assert(net == *net2);
 }
 
 void trainWithMnist()
@@ -41,7 +36,7 @@ void trainWithMnist()
     // Initialize the network for MNIST with 30 hidden neurons
     const int N(3);
     const int sizes[N] = {784,30,10};
-    Network net(sizes, N, NetworkActivationMode::Sigmoid);
+    Network net(sizes, N, ActivationType::Sigmoid, CostType::Quadratic);
     
     std::cout << "Run Stochastic Gradient Descent algorithm" << std::endl;
     size_t miniBatchSize(10), epoch(5);
@@ -57,6 +52,6 @@ void trainWithMnist()
 
 int main(int argc, const char * argv[])
 {
-//    saveAndLoad();
-    trainWithMnist();
+    saveAndLoad();
+//    trainWithMnist();
 }


### PR DESCRIPTION
…work

> ./include/algebra.hpp
- add enum class CostType (Quadratic and CrossEntropy)
- add enum class ActivationType (Sigmoid and Softmax)

> ./include/engine.hpp
Network:
- remove enum class NetworkActivationMode

Network:
- update constructor for Network to explicitly specify ActivationType and CostType
- remove constructor Network(const string& filename)
- add static method to create Network from filename (string)
- add public const members activationType and costType
- add public operator ==

> ./include/layer.hpp
BaseLayer:
- update constructor for Network to explicitly specify ActivationType
- add public method equals
- add public const members inSize and outSize
- remove private members m_inSize and m_outSize

HiddenLayer:
- update constructor to explicitly specify ActivationType OutputLayer:
- update constructor to explicitly specify ActivationType

> ./include/engine.cpp
Network:
- update method toBinary(boost::archive::binary_oarchive & ar)
- update methode loadBinary(boost::archive::binary_iarchive &ar)