### PR TITLE
Refactor _backprop implementation in class Network for more readability

### DIFF
--- a/include/algebra.hpp
+++ b/include/algebra.hpp
@@ -44,14 +44,14 @@ class Cost
 public:
     virtual ~Cost() = default;
     
-    virtual void gradient(const VectorXf& x, const VectorXf& y, VectorXf* result) const = 0;
+    virtual void getGradient(const VectorXf& computedOutput, const VectorXf& expectedOutput, VectorXf& result) const = 0;
 };
 
 class Quadratic : public Cost
 {
 public:
     Quadratic(VectorXf* derivative);
-    void gradient(const VectorXf& x, const VectorXf& y, VectorXf* result) const override;
+    void getGradient(const VectorXf& computedOutput, const VectorXf& expectedOutput, VectorXf& result) const override;
     
 private:
     VectorXf* m_derivative;
@@ -61,6 +61,6 @@ class CrossEntropy : public Cost
 {
 public:
     CrossEntropy();
-    void gradient(const VectorXf& x, const VectorXf& y, VectorXf* result) const override;
+    void getGradient(const VectorXf& computedOutput, const VectorXf& expectedOutput, VectorXf& result) const override;
 };
 #endif /* algebra_hpp */

--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -17,9 +17,11 @@ class Network
 {
 public:
     Network(const int sizes[], const int& N, const ActivationType& actiType, const CostType& costType);
+    Network& operator=(const Network&& other) = delete;
     ~Network();
     
     static Network* loadFile(const std::string& fileName);
+    static Network* loadBinary(boost::archive::binary_iarchive & ar);
     
     void SGD(Dataset& dataset, const size_t& miniBatchSize, const size_t& epoch, const float& eta, const bool displayProgress = false);
     void feedForward(VectorXf& input) const;
@@ -28,7 +30,6 @@ public:
     void to_csv(const std::string& dest) const;
     void toBinary(const std::string& dest) const;
     void toBinary(boost::archive::binary_oarchive & ar) const;
-    void loadBinary(boost::archive::binary_iarchive & ar) const;
     
     void getStats() const;
         
@@ -55,6 +56,5 @@ private:
     void _backprop(const DataPair& datapair) const;
     void _updateMiniBatch(size_t& offset, Dataset& dataset);
     void _updateWeightsAndBiases();
-    void _updateWeightsAndBiasesAndEvaluateDelta(const Dataset& dataset);
 };
 #endif /* engine_hpp */

--- a/include/export.hpp
+++ b/include/export.hpp
@@ -7,7 +7,7 @@
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 
-void export_to_csv(Eigen::MatrixXf* matrix, const std::string& dest);
-void export_to_csv(Eigen::VectorXf* vector, const std::string& dest);
+void export_to_csv(const Eigen::MatrixXf& matrix, const std::string& dest);
+void export_to_csv(const Eigen::VectorXf& vector, const std::string& dest);
 
 #endif /* export_hpp */

--- a/src/algebra.cpp
+++ b/src/algebra.cpp
@@ -39,15 +39,15 @@ void Softmax::prim(VectorXf& input, VectorXf& output) const
 
 Quadratic::Quadratic(VectorXf* derivative):m_derivative(derivative){}
 
-void Quadratic::gradient(const VectorXf &x, const VectorXf &y, VectorXf* result) const
+void Quadratic::getGradient(const VectorXf& computedOutput, const VectorXf& expectedOutput, VectorXf& result) const
 {
     // NablaC = x-y
-    *result = (x-y).array() * this->m_derivative->array();
+    result = (computedOutput-expectedOutput).array() * this->m_derivative->array();
 }
 
 CrossEntropy::CrossEntropy(){}
 
-void CrossEntropy::gradient(const VectorXf &x, const VectorXf &y, VectorXf* result) const
+void CrossEntropy::getGradient(const VectorXf& computedOutput, const VectorXf& expectedOutput, VectorXf& result) const
 {
-    *result = (x-y).array();
+    result = (computedOutput-expectedOutput).array();
 }

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -11,17 +11,17 @@ using namespace std;
 using Eigen::MatrixXf;
 using Eigen::VectorXf;
 
-void export_to_csv(MatrixXf* matrix, const string& dest)
+void export_to_csv(const MatrixXf& matrix, const string& dest)
 {
     ofstream outputFile(dest);
     if(outputFile.is_open())
     {
-        for(int i(0); i<matrix->rows(); i++)
+        for(int i(0); i<matrix.rows(); i++)
         {
-            for(int j(0); j<matrix->cols(); j++)
+            for(int j(0); j<matrix.cols(); j++)
             {
-                outputFile << (*matrix)(i, j);
-                if (j < matrix->cols() - 1)
+                outputFile << matrix(i, j);
+                if (j < matrix.cols() - 1)
                 {
                     outputFile << ",";
                 }
@@ -32,14 +32,14 @@ void export_to_csv(MatrixXf* matrix, const string& dest)
     outputFile.close();
 }
 
-void export_to_csv(VectorXf* vector, const string& dest)
+void export_to_csv(const VectorXf& vector, const string& dest)
 {
     ofstream outputFile(dest);
     if(outputFile.is_open())
     {
-        for(int i(0); i<vector->size(); i++)
+        for(int i(0); i<vector.size(); i++)
         {
-            outputFile << (*vector)(i);
+            outputFile << vector(i);
             outputFile << "\n";
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,127 @@
+#include <iostream>
+#include "mnist.hpp"
+#include "dataset.hpp"
+#include "engine.hpp"
+#include <chrono>
+#include <fstream>
+
+void saveAndLoad()
+{
+    // Initialize a network with 3 hidden layers
+    const int N(5);
+    const int sizes[N] = {100, 30, 25, 20, 10};
+    Network net(sizes, N, ActivationType::Sigmoid, CostType::Quadratic);
+    
+    // Export to CSV
+    std::cout << "Exporting to CSV..." << std::endl;
+    net.to_csv("./exports/");
+    
+    // Export to binary
+    std::cout << "Exporting to binary..." << std::endl;
+    net.toBinary("./exports/myNetwork");
+    
+    // Load from binary
+    std::cout << "Loading from binary..." << std::endl;
+    Network* net2 = Network::loadFile("./exports/myNetwork");
+    if(net != *net2)
+    {
+        throw;
+    }
+    std::cout << "Test ok.\n";
+}
+
+void trainWithMnist(const ActivationType& activationType, const CostType& costType)
+{
+    Dataset dataset;
+    
+    std::cout << "Load MNIST dataset" << std::endl;
+    MNIST::load(dataset);
+    
+    // Initialize the network for MNIST with 30 hidden neurons
+    const int N(3);
+    const int sizes[N] = {784,30,10};
+
+    Network net(sizes, N, activationType, costType);
+    
+    std::cout << "Run Stochastic Gradient Descent algorithm" << std::endl;
+    size_t miniBatchSize(10), epoch(5);
+    float eta(3);
+    
+    auto start = std::chrono::high_resolution_clock::now();
+    net.SGD(dataset, miniBatchSize, epoch, eta, true);
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << "Elapsed time = " << duration.count()  << " ms" << std::endl;
+    net.toBinary("./exports/myNetwork");
+}
+
+int main(int argc, const char * argv[])
+{
+    char testToRun(0);
+    char trainActivationMode(0), trainCostMode(0);
+    if(argc == 1)
+    {
+        std::cout << "Valid arguments:\n- 1 : saveAndLoad()\n- 2 : trainWithMnist()\nInput : ";
+        std::cin >> testToRun;
+        if(testToRun == '2')
+        {
+            std::cout << "Select activation mode for training:\n- 1 : Sigmoid\n- 2 : Softmax\nInput : ";
+            std::cin >> trainActivationMode;
+            std::cout << "Select cost mode for training:\n- 1 : Quadratic\n- 2 : Cross Entropy\nInput : ";
+            std::cin >> trainCostMode;
+        }
+    }
+    else
+    {
+        testToRun = *argv[1];
+        if(testToRun == '2')
+        {
+            trainActivationMode = *argv[2];
+            trainCostMode = *argv[3];
+        }
+    }
+    
+    switch(testToRun)
+    {
+        case '1':
+            saveAndLoad();
+            break;
+        case '2':
+            std::cout << " >>> Activation type used :";
+            ActivationType actiType;
+            switch(trainActivationMode)
+            {
+                case '1':
+                    std::cout << " Sigmoid\n";
+                    actiType = ActivationType::Sigmoid;
+                    break;
+                case '2':
+                    std::cout << " Softmax\n";
+                    actiType = ActivationType::Softmax;
+                    break;
+                default:
+                    throw;
+            }
+            
+            std::cout << " >>> Cost type used :";
+            CostType costType;
+            switch(trainCostMode)
+            {
+                case '1':
+                    std::cout << " Quadratic\n";
+                    costType = CostType::Quadratic;
+                    break;
+                case '2':
+                    std::cout << " Cross Entropy\n";
+                    costType = CostType::CrossEntropy;
+                    break;
+                default:
+                    throw;
+            }
+            
+            trainWithMnist(actiType, costType);
+            break;
+        default:
+            throw;
+    }
+}


### PR DESCRIPTION
> ./include/algebra.hpp
Cost:
- rename gradient() method to getGradient() for clarity

> ./include/engine.hpp
- request compiler not to generate assignation operator
- update method loadBinary to be static and return a Network*
- remove method _updateWeightsAndBiasesAndEvaluateDelta

> ./include/export.hpp
- update arguments (l-value instead of pointer)

> ./include/layer.hpp
BaseLayer:
- request compiler not to generate assignation operator
- add method updateCost
- add method getActivation
- remove method dotProductWithActivation
- remove dotProductWithWeight
- add member m_deltaComputed to store result to be used in SGD algorithm
- update method getDelta to be non-const and store result in member m_deltaComputed for SGD
- update method equals (arguments)
- update members to use l-values instead of pointers

> ./src/engine.cpp
- refactor method _backprop